### PR TITLE
Upgrade requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask-WTF==0.12
 
 # Other libraries
 authy==2.1.2
-psycopg2==2.6.1
+psycopg2==2.7.1
 requests==2.8.1
 
 # Production server

--- a/twofa/auth/views.py
+++ b/twofa/auth/views.py
@@ -21,8 +21,8 @@ def sign_up():
 
             return redirect(url_for('main.account'))
 
-        except AuthyApiException:
-            form.errors['Authy API'] = ['There was an error creating the Authy user']
+        except AuthyApiException as e:
+            form.errors['Authy API'] = ['There was an error creating the Authy user', e.msg]
 
     return render_template('signup.html', form=form)
 
@@ -63,14 +63,17 @@ def authy_callback():
     authy_id = request.json.get('authy_id')
     # When you're configuring your Endpoint/URL under OneTouch settings '1234'
     # is the preset 'authy_id'
-    if authy_id != '1234':
-        user = User.query.filter_by(authy_id=authy_id).one()
+    if str(authy_id) != '1234':
+        user = User.query.filter_by(authy_id=authy_id).first()
 
-        user.authy_status = request.json.get('status')
-        db.session.add(user)
-        db.session.commit()
+        if user:
+            user.authy_status = request.json.get('status')
+            db.session.add(user)
+            db.session.commit()
+        else:
+            return ('', 404)
 
-    return ('', 204)
+    return ('', 200)
 
 @auth.route('/login/status')
 def login_status():

--- a/twofa/utils.py
+++ b/twofa/utils.py
@@ -1,4 +1,5 @@
 from authy.api import AuthyApiClient
+from authy import AuthyApiException
 from flask import current_app
 
 from . import db
@@ -29,7 +30,9 @@ def create_user(form):
         db.session.add(user)
         db.session.commit()
         db.session.refresh(user)
-    return user
+        return user
+    else:
+        raise AuthyApiException('', '', authy_user.errors()['message'])
 
 def send_authy_token_request(authy_user_id):
     """


### PR DESCRIPTION
- Upgraded psycopg2 version due to installation problems
- Type conversion for `1234` value for `authy_id` and more error handling in that section.
- Authy requires the response should be 200 to register the callback url, not 204.